### PR TITLE
Add Jest setup and modular filter tests

### DIFF
--- a/assets/__tests__/theme.test.js
+++ b/assets/__tests__/theme.test.js
@@ -1,0 +1,47 @@
+const filterProducts = require('../filterProducts');
+
+describe('filterProducts', () => {
+  let under100;
+  let range100to300;
+  let message;
+  let card1;
+  let card2;
+  let card3;
+
+  function setupDOM(prices) {
+    document.body.innerHTML = `
+      <input type="checkbox" data-filter="under-100" />
+      <input type="checkbox" data-filter="100-300" />
+      <div id="no-products-message"></div>
+      <div class="product-card"><span itemprop="price">${prices[0]}</span></div>
+      <div class="product-card"><span itemprop="price">${prices[1]}</span></div>
+      <div class="product-card"><span itemprop="price">${prices[2]}</span></div>
+    `;
+    under100 = document.querySelector('[data-filter="under-100"]');
+    range100to300 = document.querySelector('[data-filter="100-300"]');
+    message = document.getElementById('no-products-message');
+    [card1, card2, card3] = document.querySelectorAll('.product-card');
+  }
+
+  test('shows products under 100 and hides others', () => {
+    setupDOM([50, 200, 400]);
+    under100.checked = true;
+    filterProducts();
+
+    expect(card1.style.display).toBe('block');
+    expect(card2.style.display).toBe('none');
+    expect(card3.style.display).toBe('none');
+    expect(message.style.display).toBe('block');
+  });
+
+  test('hides all products when none match and hides message', () => {
+    setupDOM([150, 200, 400]);
+    under100.checked = true;
+    filterProducts();
+
+    expect(card1.style.display).toBe('none');
+    expect(card2.style.display).toBe('none');
+    expect(card3.style.display).toBe('none');
+    expect(message.style.display).toBe('none');
+  });
+});

--- a/assets/filterProducts.js
+++ b/assets/filterProducts.js
@@ -1,0 +1,38 @@
+function filterProducts() {
+  const selectedFilters = Array.from(document.querySelectorAll('[data-filter]:checked'))
+    .map(el => el.getAttribute('data-filter'));
+
+  const cards = document.querySelectorAll('.product-card');
+  let hasVisibleCard = false;
+
+  cards.forEach(card => {
+    const priceElement = card.querySelector('[itemprop="price"]');
+    if (!priceElement) return;
+
+    const priceText = priceElement.textContent.replace(/[^0-9.-]+/g, "");
+    const price = parseFloat(priceText);
+
+    let show = true;
+
+    if (selectedFilters.includes('under-100') && price >= 100) show = false;
+    if (selectedFilters.includes('100-300') && (price < 100 || price > 300)) show = false;
+
+    if (show) {
+      card.style.display = 'block';
+      hasVisibleCard = true;
+    } else {
+      card.style.display = 'none';
+    }
+  });
+
+  const emptyState = document.getElementById('no-products-message');
+  if (emptyState) {
+    emptyState.style.display = hasVisibleCard ? 'block' : 'none';
+  }
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = filterProducts;
+} else {
+  window.filterProducts = filterProducts;
+}

--- a/assets/index.html
+++ b/assets/index.html
@@ -17,6 +17,7 @@
   <footer class="site-footer">
     &copy; 2025 TypoScent
   </footer>
+  <script src="assets/filterProducts.js"></script>
   <script src="assets/theme.js"></script>
 </body>
 </html>

--- a/assets/theme.js
+++ b/assets/theme.js
@@ -1,3 +1,10 @@
+/* eslint-disable no-var */
+if (typeof require !== 'undefined') {
+  try {
+    var filterProducts = require('./filterProducts');
+  } catch (e) {}
+}
+
 document.addEventListener('DOMContentLoaded', function () {
   console.log("Thème Lamsat Abeer is running!");
 
@@ -80,39 +87,6 @@ document.addEventListener('DOMContentLoaded', function () {
   document.querySelectorAll('[data-filter]').forEach(input => {
     input.addEventListener('change', filterProducts);
   });
-
-  function filterProducts() {
-    const selectedFilters = Array.from(document.querySelectorAll('[data-filter]:checked'))
-                               .map(el => el.getAttribute('data-filter'));
-
-    const cards = document.querySelectorAll('.product-card');
-    let hasVisibleCard = false;
-
-    cards.forEach(card => {
-      const priceElement = card.querySelector('[itemprop="price"]');
-      if (!priceElement) return;
-
-      const priceText = priceElement.textContent.replace(/[^0-9.-]+/g, "");
-      const price = parseFloat(priceText);
-
-      let show = true;
-
-      if (selectedFilters.includes('under-100') && price >= 100) show = false;
-      if (selectedFilters.includes('100-300') && (price < 100 || price > 300)) show = false;
-
-      if (show) {
-        card.style.display = 'block';
-        hasVisibleCard = true;
-      } else {
-        card.style.display = 'none';
-      }
-    });
-
-    const emptyState = document.getElementById('no-products-message');
-    if (emptyState) {
-      emptyState.style.display = hasVisibleCard ? 'block' : 'none';
-    }
-  }
 
   // === Compare Products Functionality ===
   let compareList = [];

--- a/layout/default.liquid
+++ b/layout/default.liquid
@@ -28,6 +28,7 @@
   {{ 'theme.css.liquid' | asset_url | stylesheet_tag }}
 
   <!-- Theme JS -->
+  {{ 'filterProducts.js' | asset_url | script_tag }}
   {{ 'theme.js' | asset_url | script_tag }}
 
   <!-- Swiper.js CDN -->

--- a/package.json
+++ b/package.json
@@ -1,15 +1,22 @@
 {
     "name": "lamsat-abeer",
     "version": "1.0.0",
+    "dependencies": {
+      "salla-cli": "latest",
+      "swiper": "^8",
+      "gsap": "^3"
+    },
+    "devDependencies": {
+      "jest": "^29.6.1"
+    },
+    "jest": {
+      "testEnvironment": "jsdom"
+    },
     "scripts": {
       "build": "salla theme:build",
       "zip": "salla theme:zip",
-      "watch": "salla theme:watch"
-    },
-    "dependencies": {
-      "salla-cli": "^latest",
-      "swiper": "^8",
-      "gsap": "^3"
+      "watch": "salla theme:watch",
+      "test": "jest"
     }
   }
   


### PR DESCRIPTION
## Summary
- configure Jest test environment and script
- move filter logic to new `filterProducts.js`
- load new script in HTML and layout
- provide Jest tests for product filtering

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688445ba8f4c83339b454bba45ec741b