### PR TITLE
Fix empty state toggle logic

### DIFF
--- a/assets/__tests__/theme.test.js
+++ b/assets/__tests__/theme.test.js
@@ -1,0 +1,27 @@
+const filterProducts = require('../filterProducts');
+
+describe('filterProducts', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div id="no-products-message"></div>
+      <input type="checkbox" data-filter="under-100" />
+      <input type="checkbox" data-filter="100-300" />
+      <div class="product-card"><span itemprop="price">$50</span></div>
+      <div class="product-card"><span itemprop="price">$150</span></div>
+    `;
+  });
+
+  test('hides empty state when products are visible', () => {
+    filterProducts();
+    const message = document.getElementById('no-products-message');
+    expect(message.style.display).toBe('none');
+  });
+
+  test('shows empty state when no products are visible', () => {
+    document.querySelector('[data-filter="under-100"]').checked = true;
+    document.querySelector('[data-filter="100-300"]').checked = true;
+    filterProducts();
+    const message = document.getElementById('no-products-message');
+    expect(message.style.display).toBe('block');
+  });
+});

--- a/assets/filterProducts.js
+++ b/assets/filterProducts.js
@@ -1,0 +1,36 @@
+function filterProducts() {
+  const selectedFilters = Array.from(document.querySelectorAll('[data-filter]:checked'))
+                             .map(el => el.getAttribute('data-filter'));
+
+  const cards = document.querySelectorAll('.product-card');
+  let hasVisibleCard = false;
+
+  cards.forEach(card => {
+    const priceElement = card.querySelector('[itemprop="price"]');
+    if (!priceElement) return;
+
+    const priceText = priceElement.textContent.replace(/[^0-9.-]+/g, "");
+    const price = parseFloat(priceText);
+
+    let show = true;
+
+    if (selectedFilters.includes('under-100') && price >= 100) show = false;
+    if (selectedFilters.includes('100-300') && (price < 100 || price > 300)) show = false;
+
+    if (show) {
+      card.style.display = 'block';
+      hasVisibleCard = true;
+    } else {
+      card.style.display = 'none';
+    }
+  });
+
+  const emptyState = document.getElementById('no-products-message');
+  if (emptyState) {
+    emptyState.style.display = hasVisibleCard ? 'none' : 'block';
+  }
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = filterProducts;
+}

--- a/assets/theme.js
+++ b/assets/theme.js
@@ -110,7 +110,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
     const emptyState = document.getElementById('no-products-message');
     if (emptyState) {
-      emptyState.style.display = hasVisibleCard ? 'block' : 'none';
+      emptyState.style.display = hasVisibleCard ? 'none' : 'block';
     }
   }
 


### PR DESCRIPTION
## Summary
- update filterProducts logic to hide `#no-products-message` when products exist
- apply same fix in the theme script
- add Jest tests for the filterProducts helper

## Testing
- `npm test --silent` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68844d26f62c8333af7cf84bf1853fb6